### PR TITLE
Fix phone and SMS authentication persistence

### DIFF
--- a/custom_components/domru/__init__.py
+++ b/custom_components/domru/__init__.py
@@ -27,6 +27,7 @@ from .api import (
     DomruApiClientError,
 )
 from .const import (
+    CONF_ACCESS_TOKEN,
     CONF_OPERATOR_ID,
     CONF_REFRESH_TOKEN,
     CONF_SIP_ENABLED,
@@ -72,6 +73,9 @@ async def async_setup_entry(
         username=entry.data.get(CONF_USERNAME),
         password=entry.data.get(CONF_PASSWORD),
         session=async_get_clientsession(hass),
+        access_token=(
+            entry.data.get(CONF_ACCESS_TOKEN) or entry.data.get(CONF_REFRESH_TOKEN)
+        ),
         refresh_token=entry.data.get(CONF_REFRESH_TOKEN),
         operator_id=entry.data.get(CONF_OPERATOR_ID),
     )

--- a/custom_components/domru/api.py
+++ b/custom_components/domru/api.py
@@ -267,9 +267,17 @@ class DomruApiClient:
             method="GET",
             authenticated=False,
             success_statuses=(self.HTTP_OK, 300),
+            status_messages={
+                204: "Phone number is not registered.",
+                self.HTTP_BAD_REQUEST: "Invalid phone number or login.",
+            },
         )
 
-        return result if isinstance(result, list) else []
+        accounts = result if isinstance(result, list) else []
+        if not accounts:
+            msg = "Password authentication is required for this account."
+            raise DomruApiClientAuthenticationError(msg)
+        return accounts
 
     async def async_request_phone_confirmation(
         self,
@@ -284,6 +292,9 @@ class DomruApiClient:
             method="POST",
             json=account,
             authenticated=False,
+            status_messages={
+                429: "Too many SMS requests. Try again later.",
+            },
         )
 
     async def async_confirm_phone_code(
@@ -311,6 +322,9 @@ class DomruApiClient:
             json=json_data,
             authenticated=False,
             bad_request_message="SMS code is wrong. Try again.",
+            status_messages={
+                406: "Invalid SMS code format.",
+            },
         )
         auth_data = _auth_response_data(result)
 
@@ -863,9 +877,11 @@ class DomruApiClient:
         authenticated: bool = True,
         success_statuses: tuple[int, ...] | None = None,
         bad_request_message: str | None = None,
+        status_messages: dict[int, str] | None = None,
     ) -> Any:
         """Make an API request with automatic token refresh on 401."""
         allowed_statuses = success_statuses or (self.HTTP_OK, self.HTTP_CREATED)
+        parse_statuses = (*allowed_statuses, *(status_messages or {}))
         while True:
             try:
                 headers_to_use = headers or (
@@ -893,7 +909,7 @@ class DomruApiClient:
 
                     json_response = await self._parse_response(
                         response,
-                        allowed_statuses,
+                        parse_statuses,
                     )
 
                     # Check for error responses
@@ -902,6 +918,11 @@ class DomruApiClient:
 
                     if response.status == self.HTTP_INTERNAL_ERROR:
                         self._handle_server_error(json_response)
+
+                    if status_messages and response.status in status_messages:
+                        raise DomruApiClientAuthenticationError(
+                            status_messages[response.status]
+                        )
 
                     if response.status == self.HTTP_BAD_REQUEST and bad_request_message:
                         self._handle_bad_request_error(bad_request_message)

--- a/custom_components/domru/api.py
+++ b/custom_components/domru/api.py
@@ -846,6 +846,10 @@ class DomruApiClient:
         """Handle a request-specific 400 Bad Request error."""
         raise DomruApiClientError(message)
 
+    def _handle_authentication_error(self, message: str) -> None:
+        """Handle a request-specific authentication error."""
+        raise DomruApiClientAuthenticationError(message)
+
     async def _parse_response(
         self,
         response: aiohttp.ClientResponse,
@@ -920,7 +924,7 @@ class DomruApiClient:
                         self._handle_server_error(json_response)
 
                     if status_messages and response.status in status_messages:
-                        raise DomruApiClientAuthenticationError(
+                        self._handle_authentication_error(
                             status_messages[response.status]
                         )
 

--- a/custom_components/domru/api.py
+++ b/custom_components/domru/api.py
@@ -125,6 +125,7 @@ class DomruApiClient:
         username: str | None,
         password: str | None,
         session: aiohttp.ClientSession,
+        access_token: str | None = None,
         refresh_token: str | None = None,
         operator_id: str | int | None = None,
     ) -> None:
@@ -132,7 +133,7 @@ class DomruApiClient:
         self._username = username
         self._password = password
         self._session = session
-        self._access_token: str | None = None
+        self._access_token = access_token
         self._refresh_token = refresh_token
         self._operator_id = operator_id
         self._place_id: str | None = None
@@ -140,6 +141,11 @@ class DomruApiClient:
         # Hash parameters from go-impl/pkg/auth/password.go
         self._hash2_prefix = "DigitalHomeNTK"
         self._secret = "789sdgHJs678wertv34712376"  # noqa: S105
+
+    @property
+    def access_token(self) -> str | None:
+        """Return the current access token."""
+        return self._access_token
 
     @property
     def refresh_token(self) -> str | None:
@@ -173,6 +179,9 @@ class DomruApiClient:
 
     async def _set_access_token(self) -> None:
         """Set access token using login/password or refresh token."""
+        if self._access_token is not None:
+            return
+
         if self._refresh_token is not None and self._operator_id is not None:
             # Try to refresh token first
             try:

--- a/custom_components/domru/button.py
+++ b/custom_components/domru/button.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
-from homeassistant.const import EntityCategory
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
 from .access_control import access_control_label, valid_access_controls
@@ -28,13 +27,11 @@ ENTITY_DESCRIPTIONS = (
         key="open_door",
         name="Open Door",
         icon="mdi:door",
-        entity_category=EntityCategory.CONFIG,
     ),
     ButtonEntityDescription(
         key="dismiss_call",
         name="Dismiss Call",
         icon="mdi:phone-off",
-        entity_category=EntityCategory.CONFIG,
     ),
 )
 
@@ -88,7 +85,6 @@ def _access_control_button_description(
         key=f"open_door_{access_control_id}",
         name=f"Open {name}",
         icon="mdi:door-open",
-        entity_category=EntityCategory.CONFIG,
     )
 
 

--- a/custom_components/domru/config_flow.py
+++ b/custom_components/domru/config_flow.py
@@ -18,6 +18,7 @@ from .api import (
 from .const import (
     AUTH_METHOD_PASSWORD,
     AUTH_METHOD_PHONE,
+    CONF_ACCESS_TOKEN,
     CONF_ACCOUNT_ID,
     CONF_AUTH_METHOD,
     CONF_CAMERA_STREAM_CACHE,
@@ -277,7 +278,7 @@ class DomruFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     user_input["sms_code"],
                     self._selected_account,
                 )
-                refresh_token, operator_id = _phone_auth_tokens(client)
+                access_token, refresh_token, operator_id = _phone_auth_tokens(client)
             except DomruApiClientAuthenticationError as exception:
                 LOGGER.warning(exception)
                 self._last_error_message = _error_message(exception)
@@ -299,6 +300,7 @@ class DomruFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                         CONF_AUTH_METHOD: AUTH_METHOD_PHONE,
                         CONF_PHONE: self._phone,
                         CONF_ACCOUNT_ID: self._selected_account.get("accountId"),
+                        CONF_ACCESS_TOKEN: access_token,
                         CONF_REFRESH_TOKEN: refresh_token,
                         CONF_OPERATOR_ID: operator_id,
                     },
@@ -404,14 +406,15 @@ def _description_placeholders(message: str | None) -> dict[str, str]:
     return {"error_message": message or ""}
 
 
-def _phone_auth_tokens(client: DomruApiClient) -> tuple[str, str | int]:
+def _phone_auth_tokens(client: DomruApiClient) -> tuple[str, str, str | int]:
     """Return stored phone-login tokens or raise a config-flow auth error."""
+    access_token = client.access_token
     refresh_token = client.refresh_token
     operator_id = client.operator_id
-    if not refresh_token or operator_id is None:
-        msg = "No refresh token or operator ID in phone confirmation"
+    if not access_token or not refresh_token or operator_id is None:
+        msg = "Incomplete credentials in phone confirmation"
         raise DomruApiClientAuthenticationError(msg)
-    return refresh_token, operator_id
+    return access_token, refresh_token, operator_id
 
 
 class DomruOptionsFlowHandler(config_entries.OptionsFlow):

--- a/custom_components/domru/const.py
+++ b/custom_components/domru/const.py
@@ -13,6 +13,7 @@ CONF_CAMERA_STREAM_CACHE_TIME = "camera_stream_cache_time"
 CONF_AUTH_METHOD = "auth_method"
 CONF_PHONE = "phone"
 CONF_ACCOUNT_ID = "account_id"
+CONF_ACCESS_TOKEN = "access_token"  # noqa: S105
 CONF_REFRESH_TOKEN = "refresh_token"  # noqa: S105
 CONF_OPERATOR_ID = "operator_id"
 CONF_SIP_ENABLED = "sip_enabled"

--- a/docs/superpowers/plans/2026-07-08-phone-sms-auth.md
+++ b/docs/superpowers/plans/2026-07-08-phone-sms-auth.md
@@ -1,0 +1,202 @@
+# Phone and SMS Authentication Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reuse SMS credentials across restarts, report documented authentication failures clearly, and place all call and door buttons in Controls.
+
+**Architecture:** Store the SMS access token in config-entry data and pass it into `DomruApiClient`; existing SMS entries fall back to their stored refresh token as the access token. Keep HTTP status interpretation in the API client and expose stable exception messages to the config flow.
+
+**Tech Stack:** Python 3, Home Assistant config flows/entities, `aiohttp`, `unittest`, Ruff.
+
+---
+
+### Task 1: Persist and reuse the SMS token
+
+**Files:**
+- Modify: `custom_components/domru/const.py`
+- Modify: `custom_components/domru/api.py`
+- Modify: `custom_components/domru/config_flow.py`
+- Modify: `custom_components/domru/__init__.py`
+- Test: `tests/test_api_phone_login.py`
+- Test: `tests/test_config_flow_compat.py`
+
+- [ ] **Step 1: Write failing token-reuse tests**
+
+Add an `access_token` constructor argument test asserting that
+`async_authenticate()` makes no HTTP request, plus source compatibility checks
+asserting that config flow stores `CONF_ACCESS_TOKEN` and setup passes
+`entry.data.get(CONF_ACCESS_TOKEN) or entry.data.get(CONF_REFRESH_TOKEN)`.
+
+```python
+def test_stored_access_token_authentication_makes_no_refresh_request(self) -> None:
+    session = FakeSession()
+    client = DomruApiClient(
+        username=None,
+        password=None,
+        session=session,
+        access_token="sms-token",
+        refresh_token="sms-token",
+        operator_id=123,
+    )
+    asyncio.run(client.async_authenticate())
+    self.assertEqual(session.requests, [])
+```
+
+- [ ] **Step 2: Run the tests and verify RED**
+
+Run: `python -m unittest tests.test_api_phone_login tests.test_config_flow_compat -v`
+
+Expected: failure because `DomruApiClient` does not accept `access_token` and
+the config flow does not store it.
+
+- [ ] **Step 3: Implement direct token reuse**
+
+Add `CONF_ACCESS_TOKEN = "access_token"`; expose `client.access_token`; accept
+`access_token` in the client constructor; return immediately from
+`_set_access_token()` when it is present. Store it after SMS confirmation and in
+the config entry. During setup use:
+
+```python
+access_token=(
+    entry.data.get(CONF_ACCESS_TOKEN)
+    or entry.data.get(CONF_REFRESH_TOKEN)
+),
+```
+
+The fallback supports entries created by the previous release.
+
+- [ ] **Step 4: Run the focused tests and verify GREEN**
+
+Run: `python -m unittest tests.test_api_phone_login tests.test_config_flow_compat -v`
+
+Expected: all focused tests pass.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add custom_components/domru/const.py custom_components/domru/api.py custom_components/domru/config_flow.py custom_components/domru/__init__.py tests/test_api_phone_login.py tests/test_config_flow_compat.py
+git commit -m "fix: reuse SMS token across restarts"
+```
+
+### Task 2: Map documented phone and SMS errors
+
+**Files:**
+- Modify: `custom_components/domru/api.py`
+- Test: `tests/test_api_phone_login.py`
+
+- [ ] **Step 1: Write failing response-status tests**
+
+Add tests for phone lookup `204`, phone lookup `400`, phone lookup `200` with no
+contracts, SMS request `429`, and SMS confirmation `406`. Assert these messages:
+
+```text
+Phone number is not registered.
+Invalid phone number or login.
+Password authentication is required for this account.
+Too many SMS requests. Try again later.
+Invalid SMS code format.
+```
+
+- [ ] **Step 2: Run the tests and verify RED**
+
+Run: `python -m unittest tests.test_api_phone_login -v`
+
+Expected: failures containing generic `HTTP 204`, `HTTP 400`, `HTTP 429`, or
+`HTTP 406`, or an empty account list.
+
+- [ ] **Step 3: Implement endpoint-specific status handling**
+
+Extend `_api_wrapper()` with optional `status_messages: dict[int, str]`. Before
+generic error handling, raise `DomruApiClientAuthenticationError` using the
+mapped message. Configure the three phone endpoints with the messages above,
+and explicitly reject a successful phone-lookup response that contains no
+contract list with `Password authentication is required for this account.`
+
+- [ ] **Step 4: Run the focused tests and verify GREEN**
+
+Run: `python -m unittest tests.test_api_phone_login -v`
+
+Expected: all phone-login tests pass.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add custom_components/domru/api.py tests/test_api_phone_login.py
+git commit -m "fix: report phone authentication errors"
+```
+
+### Task 3: Move every call and door button to Controls
+
+**Files:**
+- Modify: `custom_components/domru/button.py`
+- Test: `tests/test_ha_sip_entities.py`
+
+- [ ] **Step 1: Write a failing category regression test**
+
+Read `custom_components/domru/button.py` and assert that no button description
+assigns `EntityCategory.CONFIG`:
+
+```python
+def test_call_and_door_buttons_are_control_entities(self) -> None:
+    source = Path("custom_components/domru/button.py").read_text()
+    self.assertNotIn("entity_category=EntityCategory.CONFIG", source)
+```
+
+- [ ] **Step 2: Run the test and verify RED**
+
+Run: `python -m unittest tests.test_ha_sip_entities -v`
+
+Expected: failure because base and generated door buttons are configuration
+entities.
+
+- [ ] **Step 3: Remove configuration categories**
+
+Remove the `EntityCategory` import and every
+`entity_category=EntityCategory.CONFIG` argument from `button.py`.
+
+- [ ] **Step 4: Run the test and verify GREEN**
+
+Run: `python -m unittest tests.test_ha_sip_entities -v`
+
+Expected: all SIP entity tests pass.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add custom_components/domru/button.py tests/test_ha_sip_entities.py
+git commit -m "fix: show door controls in controls section"
+```
+
+### Task 4: Full verification
+
+**Files:**
+- Verify: all changed files
+
+- [ ] **Step 1: Run the complete test suite**
+
+Run: `python -m unittest discover tests`
+
+Expected: all tests pass.
+
+- [ ] **Step 2: Run lint and formatting checks**
+
+Run: `python -m ruff check .`
+
+Expected: exit code 0.
+
+Run: `python -m ruff format . --check`
+
+Expected: exit code 0.
+
+- [ ] **Step 3: Check patch integrity**
+
+Run: `git diff --check`
+
+Expected: no output.
+
+- [ ] **Step 4: Inspect repository state**
+
+Run: `git status --short --branch`
+
+Expected: only the local untracked `.codex/` directory remains.
+

--- a/docs/superpowers/specs/2026-07-08-phone-sms-auth-design.md
+++ b/docs/superpowers/specs/2026-07-08-phone-sms-auth-design.md
@@ -1,0 +1,53 @@
+# Phone and SMS Authentication Reliability Design
+
+## Goal
+
+Make phone and SMS config entries usable immediately and after Home Assistant
+restarts, expose readable errors for the documented authentication responses,
+and show all door and call buttons in Home Assistant's Controls section.
+
+## Authentication
+
+The SMS confirmation response returns an opaque access token and a refresh token
+with the same value. The integration will store the access token in the config
+entry and initialize the API client with it. On startup, an SMS-authenticated
+entry will reuse that token directly instead of calling the uncertain
+`/auth/v2/session/refresh` endpoint.
+
+Password authentication remains unchanged. Existing SMS entries that contain
+only `refresh_token` will treat that value as the reusable access token, which
+provides backward compatibility without asking the user for another SMS code.
+
+This change does not alter config-entry unique IDs or account selection.
+
+## Flow errors
+
+The phone and SMS flow will translate the documented API outcomes into readable
+Home Assistant errors:
+
+- phone lookup `204`: the phone is not registered;
+- phone lookup `400`: the phone/login format is invalid;
+- phone lookup `200` without contracts: password authentication is required;
+- SMS request `429`: too many SMS requests; retry later;
+- SMS confirmation `406`: the SMS code format is invalid;
+- known invalid-code responses: the SMS code is incorrect and can be retried.
+
+The flow remains on the relevant step so the user can correct the input without
+restarting configuration.
+
+## Button placement
+
+Remove `EntityCategory.CONFIG` from `open_door`, `dismiss_call`, and every
+dynamically generated `open_door_*` button. Home Assistant will therefore place
+all of them in Controls.
+
+## Testing
+
+Add regression coverage before implementation for:
+
+- direct reuse of a stored SMS token without a refresh request;
+- backward compatibility with existing refresh-token-only SMS entries;
+- persistence of the SMS access token in new config entries;
+- each documented phone/SMS error mapping;
+- absence of the configuration entity category from all call/door buttons.
+

--- a/tests/test_api_phone_login.py
+++ b/tests/test_api_phone_login.py
@@ -413,9 +413,7 @@ class ApiPhoneLoginTests(unittest.TestCase):
             api_module.DomruApiClientAuthenticationError,
             "Invalid SMS code format",
         ):
-            asyncio.run(
-                client.async_confirm_phone_code("+79991112233", "x", account)
-            )
+            asyncio.run(client.async_confirm_phone_code("+79991112233", "x", account))
 
     def test_refresh_token_authentication_does_not_require_password(self) -> None:
         session = FakeSession(

--- a/tests/test_api_phone_login.py
+++ b/tests/test_api_phone_login.py
@@ -164,6 +164,36 @@ class ApiPhoneLoginTests(unittest.TestCase):
 
         self.assertEqual(accounts, [{"accountId": "account-1"}])
 
+    def test_get_phone_accounts_reports_unregistered_phone(self) -> None:
+        session = FakeSession(FakeResponse(None, status=204))
+        client = DomruApiClient(username=None, password=None, session=session)
+
+        with self.assertRaisesRegex(
+            api_module.DomruApiClientAuthenticationError,
+            "Phone number is not registered",
+        ):
+            asyncio.run(client.async_get_phone_accounts("+79991112233"))
+
+    def test_get_phone_accounts_reports_invalid_login(self) -> None:
+        session = FakeSession(FakeResponse({"error": "invalid_login"}, status=400))
+        client = DomruApiClient(username=None, password=None, session=session)
+
+        with self.assertRaisesRegex(
+            api_module.DomruApiClientAuthenticationError,
+            "Invalid phone number or login",
+        ):
+            asyncio.run(client.async_get_phone_accounts("+79991112233"))
+
+    def test_get_phone_accounts_reports_password_flow(self) -> None:
+        session = FakeSession(FakeResponse([], status=200))
+        client = DomruApiClient(username=None, password=None, session=session)
+
+        with self.assertRaisesRegex(
+            api_module.DomruApiClientAuthenticationError,
+            "Password authentication is required",
+        ):
+            asyncio.run(client.async_get_phone_accounts("+79991112233"))
+
     def test_request_phone_confirmation_posts_selected_account(self) -> None:
         account = {
             "accountId": "account-1",
@@ -211,6 +241,23 @@ class ApiPhoneLoginTests(unittest.TestCase):
         asyncio.run(client.async_request_phone_confirmation("+79991112233", account))
 
         self.assertEqual(len(session.requests), 1)
+
+    def test_request_phone_confirmation_reports_rate_limit(self) -> None:
+        account = {
+            "accountId": "account-1",
+            "operatorId": 123,
+            "subscriberId": 456,
+        }
+        session = FakeSession(FakeResponse({"error": "limit_exceeded"}, status=429))
+        client = DomruApiClient(username=None, password=None, session=session)
+
+        with self.assertRaisesRegex(
+            api_module.DomruApiClientAuthenticationError,
+            "Too many SMS requests. Try again later",
+        ):
+            asyncio.run(
+                client.async_request_phone_confirmation("+79991112233", account)
+            )
 
     def test_confirm_phone_code_posts_confirmation_and_stores_tokens(self) -> None:
         account = {
@@ -352,6 +399,23 @@ class ApiPhoneLoginTests(unittest.TestCase):
 
         self.assertIsNone(client.refresh_token)
         self.assertIsNone(client.operator_id)
+
+    def test_confirm_phone_code_http_406_reports_invalid_format(self) -> None:
+        account = {
+            "accountId": "account-1",
+            "operatorId": 123,
+            "subscriberId": 456,
+        }
+        session = FakeSession(FakeResponse({"error": "invalid_format"}, status=406))
+        client = DomruApiClient(username=None, password=None, session=session)
+
+        with self.assertRaisesRegex(
+            api_module.DomruApiClientAuthenticationError,
+            "Invalid SMS code format",
+        ):
+            asyncio.run(
+                client.async_confirm_phone_code("+79991112233", "x", account)
+            )
 
     def test_refresh_token_authentication_does_not_require_password(self) -> None:
         session = FakeSession(

--- a/tests/test_api_phone_login.py
+++ b/tests/test_api_phone_login.py
@@ -127,6 +127,23 @@ class FakeSession:
 class ApiPhoneLoginTests(unittest.TestCase):
     """Phone login request behavior."""
 
+    def test_stored_access_token_authentication_makes_no_refresh_request(
+        self,
+    ) -> None:
+        session = FakeSession()
+        client = DomruApiClient(
+            username=None,
+            password=None,
+            session=session,
+            access_token="sms-token",
+            refresh_token="sms-token",
+            operator_id=123,
+        )
+
+        asyncio.run(client.async_authenticate())
+
+        self.assertEqual(session.requests, [])
+
     def test_get_phone_accounts_escapes_phone_number(self) -> None:
         session = FakeSession(FakeResponse([{"accountId": "account-1"}]))
         client = DomruApiClient(username=None, password=None, session=session)

--- a/tests/test_config_flow_compat.py
+++ b/tests/test_config_flow_compat.py
@@ -30,8 +30,15 @@ class ConfigFlowCompatibilityTests(unittest.TestCase):
     def test_phone_flow_stores_normalized_client_tokens(self) -> None:
         source = Path("custom_components/domru/config_flow.py").read_text()
 
+        self.assertIn("client.access_token", source)
         self.assertIn("client.refresh_token", source)
         self.assertIn("client.operator_id", source)
+
+    def test_setup_reuses_access_token_for_existing_phone_entries(self) -> None:
+        source = Path("custom_components/domru/__init__.py").read_text()
+
+        self.assertIn("entry.data.get(CONF_ACCESS_TOKEN)", source)
+        self.assertIn("or entry.data.get(CONF_REFRESH_TOKEN)", source)
 
 
 if __name__ == "__main__":

--- a/tests/test_ha_sip_entities.py
+++ b/tests/test_ha_sip_entities.py
@@ -43,6 +43,11 @@ class FakeSipClient:
 class SipEntityHelperTests(unittest.TestCase):
     """SIP helper behavior for HA platform wrappers."""
 
+    def test_call_and_door_buttons_are_control_entities(self) -> None:
+        source = Path("custom_components/domru/button.py").read_text()
+
+        self.assertNotIn("entity_category=EntityCategory.CONFIG", source)
+
     def test_button_keys_are_open_and_dismiss_only(self) -> None:
         self.assertEqual(
             sip_entities.SIP_BUTTON_KEYS,


### PR DESCRIPTION
## Summary

- Persist and directly reuse the opaque token returned by SMS confirmation.
- Keep backward compatibility with existing SMS entries by treating their stored refresh token as the access token.
- Map documented phone lookup, SMS request, and SMS confirmation failures to readable config-flow errors.
- Move all open-door and dismiss-call buttons from Configuration to Controls.

## Root cause

SMS login returns the same opaque value as both accessToken and refreshToken. Entry setup discarded the access token and attempted the uncertain session-refresh endpoint on every restart. When refresh failed, authentication fell through to username/password even though phone-login entries have neither, producing No credentials provided.

## User impact

Phone/SMS entries now work after setup and Home Assistant restarts without requesting another SMS code. Existing entries remain compatible. Authentication failures show actionable messages, and call/door actions appear in Controls.

## Validation

- python -m unittest discover tests — 86 tests passed
- python -m ruff check .
- python -m ruff format . --check
- git diff --check